### PR TITLE
terminalの設定を変更

### DIFF
--- a/vimrc/_vimrc
+++ b/vimrc/_vimrc
@@ -46,3 +46,8 @@ imap { {}<LEFT>
 imap [ []<LEFT>
 imap ( ()<LEFT>
 
+" windowの下にterminalを開く
+set splitbelow
+
+" terminalサイズの指定
+set termwinsize=7x0


### PR DESCRIPTION
- 下半分にterminalを表示
- terminalサイズを7x0に変更